### PR TITLE
fix: use main as default docker branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN     apk --update --no-cache add \
 WORKDIR /rtwatch
 
 ARG     REPO=https://github.com/pion/rtwatch.git
-ARG     BRANCH=master
+ARG     BRANCH=main
 
 RUN     echo -e "GIT Repo: $REPO\nGIT Branch: $BRANCH"
 


### PR DESCRIPTION
#### Description
fix docker build failure by changing the default branch from master to main

#### Reference issue
Fixes #...
