### PR TITLE
add prefix path hosting option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ARG     BRANCH=main
 
 RUN     echo -e "GIT Repo: $REPO\nGIT Branch: $BRANCH"
 
-RUN     git clone https://github.com/pion/rtwatch.git --progress --verbose --branch $BRANCH /rtwatch
+RUN     git clone $REPO --progress --verbose --branch $BRANCH /rtwatch
 
 RUN     go install
 
@@ -28,6 +28,8 @@ RUN     apk --update --no-cache add \
         gstreamer
 
 COPY    --from=0 /go/bin/rtwatch /usr/local/bin/rtwatch
+
+EXPOSE 8080
 
 ENTRYPOINT      [ "/usr/local/bin/rtwatch" ]
 CMD             [ "-container-path", "https://ia800207.us.archive.org/15/items/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.mp4" ]

--- a/home.html
+++ b/home.html
@@ -20,7 +20,8 @@
 		<script>
  			const path = window.location.pathname === '/' ? '' : window.location.pathname
 			let conn = new WebSocket('ws://' + window.location.host + path + '/ws')
-			let pc = new RTCPeerConnection()
+      const stuns = ["stun:stun.schlund.de:3478"]
+      let pc = new RTCPeerConnection({iceServers: [{urls: stuns}]})
 
 			pc.onconnectionstatechange = () => {
 				document.getElementById('connectionState').innerText = pc.connectionState

--- a/home.html
+++ b/home.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>rtwatch</title>
+	</head>
+	<body id="body">
+		<video id="video1" autoplay playsinline controls></video>
+
+		<div>
+		  <input type="number" id="seekTime" value="30">
+		  <button type="button" onClick="seekClick()">Seek</button>
+		  <button type="button" onClick="playClick()">Play</button>
+		  <button type="button" onClick="pauseClick()">Pause</button>
+		</div>
+
+		<div>
+		  Connection State: <span id="connectionState"> </span>
+		</div>
+
+		<script>
+ 			const path = window.location.pathname === '/' ? '' : window.location.pathname
+			let conn = new WebSocket('ws://' + window.location.host + path + '/ws')
+			let pc = new RTCPeerConnection()
+
+			pc.onconnectionstatechange = () => {
+				document.getElementById('connectionState').innerText = pc.connectionState
+			}
+
+			window.seekClick = () => {
+				conn.send(JSON.stringify({event: 'seek', data: document.getElementById('seekTime').value}))
+			}
+			window.playClick = () => {
+				conn.send(JSON.stringify({event: 'play', data: ''}))
+			}
+			window.pauseClick = () => {
+				conn.send(JSON.stringify({event: 'pause', data: ''}))
+			}
+
+			pc.ontrack = function (event) {
+			  var el = document.getElementById('video1')
+			  el.srcObject = event.streams[0]
+			}
+
+			conn.onopen = () => {
+				pc.addTransceiver('audio', { direction: 'recvonly' });
+				pc.addTransceiver('video', { direction: 'recvonly' });
+				pc.createOffer().then(offer => {
+					pc.setLocalDescription(offer)
+					conn.send(JSON.stringify({event: 'offer', data: JSON.stringify(offer)}))
+				})
+			}
+			conn.onclose = evt => {
+				console.log('Connection closed')
+			}
+			conn.onmessage = evt => {
+				let msg = JSON.parse(evt.data)
+				if (!msg) {
+					return console.log('failed to parse msg')
+				}
+
+				switch (msg.event) {
+				case 'answer':
+					answer = JSON.parse(msg.data)
+					if (!answer) {
+						return console.log('failed to parse answer')
+					}
+					pc.setRemoteDescription(answer)
+				}
+			}
+			window.conn = conn
+		</script>
+	</body>
+</html>

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-gst/go-gst/gst"
@@ -21,81 +22,12 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/pion/webrtc/v4"
 	"github.com/pion/webrtc/v4/pkg/media"
+
+	_ "embed"
 )
 
-const homeHTML = `<!DOCTYPE html>
-<html lang="en">
-	<head>
-		<title>rtwatch</title>
-	</head>
-	<body id="body">
-		<video id="video1" autoplay playsinline controls></video>
-
-		<div>
-		  <input type="number" id="seekTime" value="30">
-		  <button type="button" onClick="seekClick()">Seek</button>
-		  <button type="button" onClick="playClick()">Play</button>
-		  <button type="button" onClick="pauseClick()">Pause</button>
-		</div>
-
-		<div>
-		  Connection State: <span id="connectionState"> </span>
-		</div>
-
-		<script>
-			let conn = new WebSocket('ws://' + window.location.host + '/ws')
-			let pc = new RTCPeerConnection()
-
-			pc.onconnectionstatechange = () => {
-				document.getElementById('connectionState').innerText = pc.connectionState
-			}
-
-			window.seekClick = () => {
-				conn.send(JSON.stringify({event: 'seek', data: document.getElementById('seekTime').value}))
-			}
-			window.playClick = () => {
-				conn.send(JSON.stringify({event: 'play', data: ''}))
-			}
-			window.pauseClick = () => {
-				conn.send(JSON.stringify({event: 'pause', data: ''}))
-			}
-
-			pc.ontrack = function (event) {
-			  var el = document.getElementById('video1')
-			  el.srcObject = event.streams[0]
-			}
-
-			conn.onopen = () => {
-				pc.addTransceiver('audio', { direction: 'recvonly' });
-				pc.addTransceiver('video', { direction: 'recvonly' });
-				pc.createOffer().then(offer => {
-					pc.setLocalDescription(offer)
-					conn.send(JSON.stringify({event: 'offer', data: JSON.stringify(offer)}))
-				})
-			}
-			conn.onclose = evt => {
-				console.log('Connection closed')
-			}
-			conn.onmessage = evt => {
-				let msg = JSON.parse(evt.data)
-				if (!msg) {
-					return console.log('failed to parse msg')
-				}
-
-				switch (msg.event) {
-				case 'answer':
-					answer = JSON.parse(msg.data)
-					if (!answer) {
-						return console.log('failed to parse answer')
-					}
-					pc.setRemoteDescription(answer)
-				}
-			}
-			window.conn = conn
-		</script>
-	</body>
-</html>
-`
+//go:embed home.html
+var homeHTML string
 
 // nolint: gochecknoglobals
 var (
@@ -123,12 +55,17 @@ func main() {
 
 	containerPath := ""
 	httpListenAddress := ""
+	httpPathPrefix := ""
 	flag.StringVar(&containerPath, "container-path", "", "path to the media file you want to playback")
 	flag.StringVar(&httpListenAddress, "http-listen-address", ":8080", "address for HTTP server to listen on")
+	flag.StringVar(&httpPathPrefix, "http-path-prefix", "", "prefix to host this application from")
 	flag.Parse()
 
 	if containerPath == "" {
 		panic("-container-path must be specified")
+	}
+	if httpPathPrefix != "" && (!strings.HasPrefix(httpPathPrefix, "/") || strings.HasSuffix(httpPathPrefix, "/")) {
+		panic("-http-path-prefix must begin with a '/', or be empty, but must not end with a '/'")
 	}
 
 	settingEngine.SetNetworkTypes([]webrtc.NetworkType{
@@ -160,11 +97,27 @@ func main() {
 
 	createPipeline(containerPath)
 
-	http.HandleFunc("/", serveHome)
-	http.HandleFunc("/ws", serveWs)
+	mux := http.NewServeMux()
 
-	fmt.Printf("Video file '%s' is now available on '%s', have fun! \n", containerPath, httpListenAddress)
-	log.Fatal(http.ListenAndServe(httpListenAddress, nil)) // nolint: gosec
+	mux.HandleFunc("/", serveHome)
+	mux.HandleFunc("/ws", serveWs)
+
+	var handler http.Handler = mux
+
+	if httpPathPrefix != "" {
+		// mux for the new root path
+		prefixMux := http.NewServeMux()
+		// handle /prefix as the home page
+		prefixMux.HandleFunc(httpPathPrefix, serveHome)
+		// redirect /prefix/ to /prefix
+		prefixMux.Handle(fmt.Sprintf("%s/{$}", httpPathPrefix), http.RedirectHandler(httpPathPrefix, http.StatusMovedPermanently))
+		// forward /prefix/... to the original mux without /prefix
+		prefixMux.Handle(fmt.Sprintf("%s/", httpPathPrefix), http.StripPrefix(httpPathPrefix, mux))
+		handler = prefixMux
+	}
+
+	fmt.Printf("Video file '%s' is now available on '%s%s', have fun! \n", containerPath, httpListenAddress, httpPathPrefix)
+	log.Fatal(http.ListenAndServe(httpListenAddress, handler)) // nolint: gosec
 }
 
 func handleWebsocketMessage(pc *webrtc.PeerConnection, ws *websocket.Conn, message *websocketMessage) error { // nolint: cyclop,lll
@@ -268,7 +221,7 @@ func serveWs(w http.ResponseWriter, r *http.Request) { // nolint: cyclop
 
 func serveHome(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	_, _ = fmt.Fprint(w, homeHTML)
+	fmt.Fprint(w, homeHTML)
 }
 
 func createPipeline(containerPath string) {


### PR DESCRIPTION
#### Description

Add an option to host rtwatch under a prefix. Using a new command line option `-http-path-prefix`. The option defaults to `""` which preserves the existing behaviour.

When self hosting it is nice to put all applications under different paths, instead of having to create subdomains for every application.

This did require a change to the `home.html` document, which doesn't show up nicely in the PR's diff:

```diff
-			let conn = new WebSocket('ws://' + window.location.host + '/ws')
+ 			const path = window.location.pathname === '/' ? '' : window.location.pathname
+			let conn = new WebSocket('ws://' + window.location.host + path + '/ws')
```

Without any prefix, window.location.pathname is `/`. With a prefix of "/foo" it is `/foo`