### PR TITLE
Auto match libunwind version

### DIFF
--- a/.github/.ci.conf
+++ b/.github/.ci.conf
@@ -12,7 +12,7 @@ function _install_dependencies_hook(){
   set -e
 
   sudo apt-get update
-  sudo apt-get purge -y libunwind-14-dev
+  sudo apt-get purge -y '?and(?installed,?name(^libunwind-[0-9]+-dev$))'
   sudo apt-get install -y libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
   sudo apt-get install -y libavcodec-dev libavutil-dev libavfilter-dev libswscale-dev libavformat-dev libavdevice-dev
 }


### PR DESCRIPTION
#### Description
The CI breaks because we look to purge libunwind-14-dev but we upgraded to Ubuntu 26 and it has libunwind-20-dev? instead, this makes the version matching automatic.